### PR TITLE
Add reusable math quiz modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# Math
-Mathgames
+# Math Quiz App
+
+Reusable TypeScript modules for a math quiz application.
+
+## Scripts
+
+- `npm run build` - compile TypeScript
+- `npm test` - run unit tests
+
+## Data
+
+- Questions reside in `src/data/questions.ts`
+- The sample set includes geometry and trick problems

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "math-quiz-app",
+  "version": "1.0.0",
+  "description": "Reusable math quiz app components",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node dist/tests/runTests.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -1,0 +1,68 @@
+import { Question } from '../types';
+
+export const questions: Question[] = [
+  {
+    id: 1,
+    category: 'algebra',
+    difficulty: 1,
+    questionLatex: '1+1=\\,?',
+    answer: '2',
+    explanationLatex: '1+1=2'
+  },
+  {
+    id: 2,
+    category: 'geometry',
+    difficulty: 2,
+    questionLatex: '\\text{Area of a triangle with base }4\\text{ and height }3?',
+    answer: '6',
+    explanationLatex: '1/2\\times4\\times3=6'
+  },
+  {
+    id: 3,
+    category: 'geometry',
+    difficulty: 1,
+    questionLatex: '\\text{Hypotenuse of a right triangle with legs }3\\text{ and }4?',
+    answer: '5',
+    explanationLatex: '\\sqrt{3^2+4^2}=5'
+  },
+  {
+    id: 4,
+    category: 'trick',
+    difficulty: 2,
+    questionLatex: '1-2+3-4+\\cdots+99-100\\,=\\,?',
+    answer: '-50',
+    explanationLatex: '\\text{Each pair sums to }-1\\text{ for 50 pairs}'
+  },
+  {
+    id: 5,
+    category: 'geometry',
+    difficulty: 2,
+    questionLatex: '\\text{Area of a circle with radius }2?',
+    answer: '4\\pi',
+    explanationLatex: '\\pi\\times2^2=4\\pi'
+  },
+  {
+    id: 6,
+    category: 'geometry',
+    difficulty: 1,
+    questionLatex: '\\text{Sum of interior angles of a pentagon?}',
+    answer: '540^\\circ',
+    explanationLatex: '(5-2)\\times180^\\circ=540^\\circ'
+  },
+  {
+    id: 7,
+    category: 'algebra',
+    difficulty: 2,
+    questionLatex: '\\frac{x^2-1}{x-1}\\text{ for }x\\neq1',
+    answer: 'x+1',
+    explanationLatex: 'x^2-1=(x-1)(x+1)'
+  },
+  {
+    id: 8,
+    category: 'geometry',
+    difficulty: 3,
+    questionLatex: '\\text{Area of a square with diagonal }\\sqrt{2}?',
+    answer: '1',
+    explanationLatex: '\\frac{(\\sqrt{2})^2}{2}=1'
+  }
+];

--- a/src/functions/categoryFilter.ts
+++ b/src/functions/categoryFilter.ts
@@ -1,0 +1,13 @@
+import { Question } from '../types';
+
+export function categoryFilter(
+  qs: Question[],
+  category?: string,
+  difficulty?: number
+): Question[] {
+  return qs.filter((q) => {
+    const catOk = category ? q.category === category : true;
+    const diffOk = difficulty ? q.difficulty === difficulty : true;
+    return catOk && diffOk;
+  });
+}

--- a/src/functions/evaluateAnswer.ts
+++ b/src/functions/evaluateAnswer.ts
@@ -1,0 +1,3 @@
+export function evaluateAnswer(correct: string, given: string): boolean {
+  return correct.trim() === given.trim();
+}

--- a/src/functions/fetchQuestion.ts
+++ b/src/functions/fetchQuestion.ts
@@ -1,0 +1,13 @@
+import { questions } from '../data/questions';
+import { Question } from '../types';
+import { categoryFilter } from './categoryFilter';
+import { shuffleQuestions } from './shuffleQuestions';
+
+export function fetchQuestion(
+  category?: string,
+  difficulty?: number
+): Question | undefined {
+  const filtered = categoryFilter(questions, category, difficulty);
+  const shuffled = shuffleQuestions(filtered);
+  return shuffled[0];
+}

--- a/src/functions/renderLatex.ts
+++ b/src/functions/renderLatex.ts
@@ -1,0 +1,7 @@
+/**
+ * Placeholder for LaTeX to image conversion.
+ * Returns the original LaTeX string for now.
+ */
+export function renderLatex(latex: string): string {
+  return latex;
+}

--- a/src/functions/shuffleQuestions.ts
+++ b/src/functions/shuffleQuestions.ts
@@ -1,0 +1,10 @@
+import { Question } from '../types';
+
+export function shuffleQuestions(qs: Question[]): Question[] {
+  const arr = [...qs];
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+export * from './functions/fetchQuestion';
+export * from './functions/renderLatex';
+export * from './functions/evaluateAnswer';
+export * from './functions/shuffleQuestions';
+export * from './functions/categoryFilter';
+export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+export interface Question {
+  id: number;
+  category: string;
+  difficulty: number;
+  questionLatex: string;
+  answer: string;
+  explanationLatex: string;
+}

--- a/tests/categoryFilter.test.ts
+++ b/tests/categoryFilter.test.ts
@@ -1,0 +1,9 @@
+import { categoryFilter } from '../src/functions/categoryFilter';
+import { questions } from '../src/data/questions';
+import { assertEqual } from './helpers';
+
+export function run() {
+  const filtered = categoryFilter(questions, 'algebra', 1);
+  assertEqual(filtered.length, 1);
+  assertEqual(filtered[0].id, 1);
+}

--- a/tests/evaluateAnswer.test.ts
+++ b/tests/evaluateAnswer.test.ts
@@ -1,0 +1,7 @@
+import { evaluateAnswer } from '../src/functions/evaluateAnswer';
+import { assert } from './helpers';
+
+export function run() {
+  assert(evaluateAnswer('2', '2'));
+  assert(!evaluateAnswer('2', '3'));
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,16 @@
+export function assert(condition: boolean, message?: string): void {
+  if (!condition) {
+    throw new Error(message || 'Assertion failed');
+  }
+}
+
+export function assertEqual<T>(a: T, b: T, message?: string): void {
+  assert(a === b, message || `${a} !== ${b}`);
+}
+
+export function assertArrayEqual<T>(a: T[], b: T[], message?: string): void {
+  assert(a.length === b.length, message || 'Array length mismatch');
+  for (let i = 0; i < a.length; i++) {
+    assert(a[i] === b[i], message || `Array element mismatch at index ${i}`);
+  }
+}

--- a/tests/questionsData.test.ts
+++ b/tests/questionsData.test.ts
@@ -1,0 +1,9 @@
+import { questions } from '../src/data/questions';
+import { assert } from './helpers';
+
+export function run() {
+  assert(questions.length >= 8, 'Expected at least 8 questions');
+  const categories = new Set(questions.map((q) => q.category));
+  assert(categories.has('geometry'), 'Missing geometry questions');
+  assert(categories.has('trick'), 'Missing trick questions');
+}

--- a/tests/runTests.ts
+++ b/tests/runTests.ts
@@ -1,0 +1,11 @@
+import { run as runShuffle } from './shuffleQuestions.test';
+import { run as runCategory } from './categoryFilter.test';
+import { run as runEval } from './evaluateAnswer.test';
+import { run as runData } from './questionsData.test';
+
+runShuffle();
+runCategory();
+runEval();
+runData();
+
+console.log('All tests passed');

--- a/tests/shuffleQuestions.test.ts
+++ b/tests/shuffleQuestions.test.ts
@@ -1,0 +1,11 @@
+import { shuffleQuestions } from '../src/functions/shuffleQuestions';
+import { questions } from '../src/data/questions';
+import { assertArrayEqual, assertEqual } from './helpers';
+
+export function run() {
+  const shuffled = shuffleQuestions(questions);
+  assertEqual(shuffled.length, questions.length);
+  const ids = shuffled.map((q) => q.id).sort();
+  const originalIds = questions.map((q) => q.id).sort();
+  assertArrayEqual(ids, originalIds);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "rootDir": "./",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- build TypeScript modules for fetching, shuffling, filtering and checking math quiz questions
- stub LaTeX rendering hook for future image conversion
- expand sample questions to include geometry and trick problems with data verification tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688db4e9411c8321865681292909c869