### PR TITLE
Expand question set and add data tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ Reusable TypeScript modules for a math quiz application.
 
 - `npm run build` - compile TypeScript
 - `npm test` - run unit tests
+
+## Data
+
+- Questions reside in `src/data/questions.ts`
+- The sample set includes geometry and trick problems

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -13,8 +13,56 @@ export const questions: Question[] = [
     id: 2,
     category: 'geometry',
     difficulty: 2,
-    questionLatex: '\\int_0^1 x\\,dx',
-    answer: '1/2',
-    explanationLatex: 'The integral of x from 0 to 1 is 1/2'
+    questionLatex: '\\text{Area of a triangle with base }4\\text{ and height }3?',
+    answer: '6',
+    explanationLatex: '1/2\\times4\\times3=6'
+  },
+  {
+    id: 3,
+    category: 'geometry',
+    difficulty: 1,
+    questionLatex: '\\text{Hypotenuse of a right triangle with legs }3\\text{ and }4?',
+    answer: '5',
+    explanationLatex: '\\sqrt{3^2+4^2}=5'
+  },
+  {
+    id: 4,
+    category: 'trick',
+    difficulty: 2,
+    questionLatex: '1-2+3-4+\\cdots+99-100\\,=\\,?',
+    answer: '-50',
+    explanationLatex: '\\text{Each pair sums to }-1\\text{ for 50 pairs}'
+  },
+  {
+    id: 5,
+    category: 'geometry',
+    difficulty: 2,
+    questionLatex: '\\text{Area of a circle with radius }2?',
+    answer: '4\\pi',
+    explanationLatex: '\\pi\\times2^2=4\\pi'
+  },
+  {
+    id: 6,
+    category: 'geometry',
+    difficulty: 1,
+    questionLatex: '\\text{Sum of interior angles of a pentagon?}',
+    answer: '540^\\circ',
+    explanationLatex: '(5-2)\\times180^\\circ=540^\\circ'
+  },
+  {
+    id: 7,
+    category: 'algebra',
+    difficulty: 2,
+    questionLatex: '\\frac{x^2-1}{x-1}\\text{ for }x\\neq1',
+    answer: 'x+1',
+    explanationLatex: 'x^2-1=(x-1)(x+1)'
+  },
+  {
+    id: 8,
+    category: 'geometry',
+    difficulty: 3,
+    questionLatex: '\\text{Area of a square with diagonal }\\sqrt{2}?',
+    answer: '1',
+    explanationLatex: '\\frac{(\\sqrt{2})^2}{2}=1'
   }
 ];

--- a/tests/questionsData.test.ts
+++ b/tests/questionsData.test.ts
@@ -1,0 +1,8 @@
+import { questions } from '../src/data/questions';
+import { assert, assertEqual } from './helpers';
+
+export function run() {
+  assertEqual(questions.length, 8);
+  const triangle = questions.find((q) => q.id === 2);
+  assert(triangle !== undefined && triangle.answer === '6');
+}

--- a/tests/runTests.ts
+++ b/tests/runTests.ts
@@ -1,9 +1,11 @@
 import { run as runShuffle } from './shuffleQuestions.test';
 import { run as runCategory } from './categoryFilter.test';
 import { run as runEval } from './evaluateAnswer.test';
+import { run as runData } from './questionsData.test';
 
 runShuffle();
 runCategory();
 runEval();
+runData();
 
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- extend the quiz dataset with additional geometry, algebra, and trick questions
- document the question data location in the README
- add a dataset test and integrate it into the test runner

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688db7f9c6bc8321bce1e80ab78b5d8b