### PR TITLE
Handle falsy values in categoryFilter

### DIFF
--- a/src/functions/categoryFilter.ts
+++ b/src/functions/categoryFilter.ts
@@ -6,8 +6,8 @@ export function categoryFilter(
   difficulty?: number
 ): Question[] {
   return qs.filter((q) => {
-    const catOk = category ? q.category === category : true;
-    const diffOk = difficulty ? q.difficulty === difficulty : true;
+    const catOk = category !== undefined ? q.category === category : true;
+    const diffOk = difficulty !== undefined ? q.difficulty === difficulty : true;
     return catOk && diffOk;
   });
 }

--- a/tests/categoryFilter.test.ts
+++ b/tests/categoryFilter.test.ts
@@ -1,9 +1,38 @@
 import { categoryFilter } from '../src/functions/categoryFilter';
 import { questions } from '../src/data/questions';
 import { assertEqual } from './helpers';
+import { Question } from '../src/types';
 
 export function run() {
   const filtered = categoryFilter(questions, 'algebra', 1);
   assertEqual(filtered.length, 1);
   assertEqual(filtered[0].id, 1);
+
+  // difficulty 0 should be respected
+  const zeroDiff: Question[] = [
+    {
+      id: 99,
+      category: 'algebra',
+      difficulty: 0,
+      questionLatex: '',
+      answer: '',
+      explanationLatex: ''
+    }
+  ];
+  const zeroFiltered = categoryFilter(zeroDiff, undefined, 0);
+  assertEqual(zeroFiltered.length, 1);
+
+  // empty string category should be respected
+  const emptyCat: Question[] = [
+    {
+      id: 100,
+      category: '',
+      difficulty: 1,
+      questionLatex: '',
+      answer: '',
+      explanationLatex: ''
+    }
+  ];
+  const emptyFiltered = categoryFilter(emptyCat, '', undefined);
+  assertEqual(emptyFiltered.length, 1);
 }


### PR DESCRIPTION
## Summary
- ensure `categoryFilter` respects empty string categories and zero difficulty
- add tests covering those edge cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68904a64e9d083218d0a3a68fd39b96f